### PR TITLE
Patching CVE-2007-4559

### DIFF
--- a/pyschism/forcing/source_sink/nwm.py
+++ b/pyschism/forcing/source_sink/nwm.py
@@ -317,8 +317,28 @@ class NWMElementPairings:
                     logger.info(
                         f"Extracting National Water Model stream network tar file to {DATADIR}"
                     )
-
-                    src.extractall(DATADIR)
+                    import os
+                    
+                    def is_within_directory(directory, target):
+                        
+                        abs_directory = os.path.abspath(directory)
+                        abs_target = os.path.abspath(target)
+                    
+                        prefix = os.path.commonprefix([abs_directory, abs_target])
+                        
+                        return prefix == abs_directory
+                    
+                    def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+                    
+                        for member in tar.getmembers():
+                            member_path = os.path.join(path, member.name)
+                            if not is_within_directory(path, member_path):
+                                raise Exception("Attempted Path Traversal in Tar File")
+                    
+                        tar.extractall(path, members, numeric_owner=numeric_owner) 
+                        
+                    
+                    safe_extract(src, DATADIR)
                 nwm_file = list(DATADIR.glob("**/*.gdb"))[0]
             elif len(nwm_file) == 1:
                 nwm_file = nwm_file[0]


### PR DESCRIPTION
Notes from original PR:

Hi, we are security researchers from the Advanced Research Center at Trellix. We have began a campaign to patch a widespread bug named CVE-2007-4559. CVE-2007-4559 is a 15 year old bug in the Python tarfile package. By using extract() or extractall() on a tarfile object without sanitizing input, a maliciously crafted .tar file could perform a directory path traversal attack. We found at least one unsantized extractall() in your codebase and are providing a patch for you via pull request. The patch essentially checks to see if all tarfile members will be extracted safely and throws an exception otherwise. We encourage you to use this patch or your own solution to secure against CVE-2007-4559. Further technical information about the vulnerability can be found in this blog.

If you have further questions you may contact us through this projects lead researcher Kasimir Schulz.
