### PR TITLE
Add `model_type_pahm` parameter support

### DIFF
--- a/pyschism/driver.py
+++ b/pyschism/driver.py
@@ -364,6 +364,7 @@ class ModelDriver:
                 self.config.forcings.nws.windrot = gridgr3.Windrot.default(
                     self.config.hgrid
                 )
+                self.param.opt.model_type_pahm = self.config.forcings.nws.model
 
             self.param.opt.wtiminc = self.param.core.dt
             self.param.opt.nws = self.config.forcings.nws.dtype.value

--- a/pyschism/forcing/nws/best_track.py
+++ b/pyschism/forcing/nws/best_track.py
@@ -2,8 +2,9 @@ from datetime import datetime
 import io
 import logging
 import os
-from os import PathLike
 import pathlib
+from enum import IntEnum
+from os import PathLike
 from typing import Union
 
 from matplotlib import pyplot
@@ -24,6 +25,12 @@ from pyschism.forcing.nws.nws2.sflux import SfluxDataset
 from pyschism.mesh import gridgr3
 
 
+class HurricaneModel(IntEnum):
+    SYMMETRIC = 1
+    GAHM = 10
+
+
+
 class BestTrackForcing(VortexTrack, NWS):
 
     def __init__(
@@ -32,8 +39,10 @@ class BestTrackForcing(VortexTrack, NWS):
         start_date: datetime = None,
         end_date: datetime = None,
         mode: ATCF_Mode = None,
+        hurricane_model: HurricaneModel = HurricaneModel.GAHM
     ):
 
+        self._model = hurricane_model
 
         VortexTrack.__init__(
             self,
@@ -98,6 +107,17 @@ class BestTrackForcing(VortexTrack, NWS):
     def dtype(self) -> NWSType:
         """Returns the datatype of the object"""
         return NWSType(-1)
+
+    @property
+    def model(self) -> HurricaneModel:
+        """Return hurricane model used for this best track forcing"""
+        return self._model
+
+    @model.setter
+    def model(self, value: HurricaneModel):
+        if value not in list(HurricaneModel):
+            raise ValueError(f"Invalid hurricane model specified: {value}")
+        self._model = value
 
     def clip_to_bbox(self, bbox, bbox_crs):
         msg = f'bbox must be a {Bbox} instance.'

--- a/pyschism/forcing/source_sink/nwm.py
+++ b/pyschism/forcing/source_sink/nwm.py
@@ -334,7 +334,7 @@ class NWMElementPairings:
                             if not is_within_directory(path, member_path):
                                 raise Exception("Attempted Path Traversal in Tar File")
                     
-                        tar.extractall(path, members, numeric_owner) 
+                        tar.extractall(path, members, numeric_owner=numeric_owner)
                         
                     
                     safe_extract(src, DATADIR)


### PR DESCRIPTION
Fix #63 
Fix #61 

Recently a new parameter was introduced in `param.nml` in [`90a67ff`](https://github.com/schism-dev/schism/commit/90a67ff3747a884bcb48a290a8de6946acabd9fb). This will control what model is used by integrated PaHM code, GAHM: `10` vs Symmetric: `1`