### PR TITLE
Fix windrot file for best track

### DIFF
--- a/tests/test_paramwind.py
+++ b/tests/test_paramwind.py
@@ -69,5 +69,3 @@ def test_paramwind_from_file():
         driver.write(tmpdir / 'paramwind', overwrite=True)
 
 
-if __name__ == '__main__':
-    test_paramwind()


### PR DESCRIPTION
The wind rotation object set for the best track was being ignored by the `write` function in `BestTrackForcing` class. That is fixed now and a rotation file is written.