### PR TITLE
Fix iof output configuration writer

### DIFF
--- a/pyschism/param/schout.py
+++ b/pyschism/param/schout.py
@@ -148,7 +148,7 @@ class SCHOUT(
             schout.append(f"  iout_sta={self.iout_sta}")
             schout.append(f"  nspool_sta={nspool_sta}")
         for var in dir(self):
-            if var.startswith('iof'):
+            if var.startswith('_iof'):
                 for i, state in enumerate(getattr(self, var)):
                     if state == 1:
                         schout.append(f'  {var[1:]}({i+1})={state}')
@@ -173,7 +173,7 @@ class SCHOUT(
             data['iout_sta'] = self.iout_sta
             data['nspool_sta'] = nspool_sta
         for var in dir(self):
-            if var.startswith('iof'):
+            if var.startswith('_iof'):
                 _var = var[1:]
                 data[_var] = len(getattr(self, var)) * [0]
                 for i, state in enumerate(getattr(self, var)):


### PR DESCRIPTION
The outputs for SCHOUT was not accounted for, e.g. if I set `Param` object's `schout.wind_speed`, I should see `iof_hydro(14)=1`, but, this was not working. Test code:

```
from pyschism.param import Param
p = Param()
p.schout.wind_speed = True
p.schout.to_dict()
str(p.schout)
```