### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ hgrid.make_plot(show=True)
 # NOTE: 2dm files can be read by QGIS > 3.0
 from pyschism.mesh import Hgrid
 hgrid = Hgrid.open('hgrid.gr3')
-hgrid.write("/path/to/output/file.2dm", fmt='2dm')
+hgrid.write("/path/to/output/file.2dm", format='2dm')
 ```
 ---
 ## Online manual


### PR DESCRIPTION
The hgrid.gr3 translation example uses an obsolete keyword.  It should match the definition here:

https://github.com/schism-dev/pyschism/blob/d07e72630c779702b52b64e223a9d1a6ad8c11c7/pyschism/mesh/base.py#L654-L657