### PR TITLE
era5 updates for new CDS-Beta

### DIFF
--- a/pyschism/forcing/nws/nws2/era5.py
+++ b/pyschism/forcing/nws/nws2/era5.py
@@ -307,7 +307,7 @@ class ERA5(SfluxDataset):
         nx_grid, ny_grid = self.inventory.xy_grid()
 
         ds=Dataset(self.inventory.files[0])
-        time1=ds['time']
+        time1=ds['valid_time']
         times=nc4.num2date(time1,units=time1.units,only_use_cftime_datetimes=False)
 
         for iday, date in enumerate(dates):

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setuptools.setup(
     },
     install_requires=[
         'boto3',
-        'cdsapi',
+        'cdsapi>=0.7.0',
         'cf-python',
         'cfgrib',
         'f90nml',


### PR DESCRIPTION
[[ECMWF CDS and ADS migrating to new infrastructure: Common Data Store (CDS) Engine]](https://confluence.ecmwf.int/display/CKB/Please+read%3A+CDS+and+ADS+migrating+to+new+infrastructure%3A+Common+Data+Store+%28CDS%29+Engine)

**The CDS Toolbox will be discontinued and is not migrated to the new CDS. Support will continue to be provided to CDS Toolbox users until the CDS Toolbox is shutdown in September 2024**

All users will have to:
* Create a new CDS-Beta account and accept CDS-Beta Terms & Conditions (Your existing CDS credentials will not work in CDS-Beta)
* setup the CDS API personal access token (old ones will not work)
* update 'cdsapi>=0.7.0'
* "There are a few datasets however for which API syntax may have changed"

The only change that affects pyschism that I found was the era5['time'] variable that changed to ['valid_time'].
I went thought the [CDS-Beta account setup process](https://cds-beta.climate.copernicus.eu/how-to-api) and updated the pyschism code accordingly. I tested creating the era5 forcingd with the updated code and everything seems to be working now.

