### PR TITLE
offset warning era5.py

### DIFF
--- a/pyschism/forcing/nws/nws2/era5.py
+++ b/pyschism/forcing/nws/nws2/era5.py
@@ -300,6 +300,9 @@ class ERA5(SfluxDataset):
         self.rnday=rnday
         self.end_date=self.start_date+timedelta(self.rnday + 1)
 
+        if self.start_date.hour != 0:
+            logger.warning(f'Start datetime hour different than 0. sflux will be offset by {self.start_date.hour} hours!')
+
         dates = {_: None for _ in np.arange(
             self.start_date,
             self.end_date,

--- a/pyschism/forcing/nws/nws2/era5.py
+++ b/pyschism/forcing/nws/nws2/era5.py
@@ -301,7 +301,8 @@ class ERA5(SfluxDataset):
         self.end_date=self.start_date+timedelta(self.rnday + 1)
 
         if self.start_date.hour != 0:
-            logger.warning(f'Start datetime hour different than 0. sflux will be offset by {self.start_date.hour} hours!')
+            raise ValueError(f"Start datetime hour different than 0.\
+            Start datetime must be at 00:00. Please specify a full day (no hour) that is before or equal to the model start time")
 
         dates = {_: None for _ in np.arange(
             self.start_date,


### PR DESCRIPTION
added warning in case datetime hour is different than zero. This will cause the sflux to be offset, which might not be what you expect from adding the hour to the datetime.